### PR TITLE
Allow traffic_sign_post to be broken with a pickaxe

### DIFF
--- a/common/src/main/resources/data/minecraft/tags/blocks/mineable/pickaxe.json
+++ b/common/src/main/resources/data/minecraft/tags/blocks/mineable/pickaxe.json
@@ -1297,6 +1297,7 @@
     "trafficcraft:concrete_slope_pattern_321",
     "trafficcraft:concrete_pattern_322",
     "trafficcraft:concrete_slope_pattern_322",
+    "trafficcraft:traffic_sign_post",
     "trafficcraft:traffic_sign",
     "trafficcraft:traffic_light",
     "trafficcraft:traffic_light_controller",


### PR DESCRIPTION
`trafficcraft:traffic_sign_post` is currently included in `needs_iron_pickaxe.json`, but not in `mineable/pickaxe.json`, so it cannot be dropped by any pickaxe.